### PR TITLE
Fix of Night theme handling

### DIFF
--- a/localehelper/src/main/java/androidx/appcompat/app/LocaleHelperAppCompatDelegate.kt
+++ b/localehelper/src/main/java/androidx/appcompat/app/LocaleHelperAppCompatDelegate.kt
@@ -54,8 +54,10 @@ class LocaleHelperAppCompatDelegate(private val superDelegate: AppCompatDelegate
     override fun addContentView(v: View?, lp: ViewGroup.LayoutParams?) =
         superDelegate.addContentView(v, lp)
 
-    override fun attachBaseContext2(context: Context) =
-        wrap(superDelegate.attachBaseContext2(super.attachBaseContext2(context)))
+    override fun attachBaseContext2(originalContext: Context): Context {
+        val superDelegateContext = super.attachBaseContext2(originalContext)
+        return wrap(superDelegateContext)
+    }
 
     override fun setTitle(title: CharSequence?) = superDelegate.setTitle(title)
 

--- a/localehelper/src/main/java/com/zeugmasolutions/localehelper/LocaleHelperActivities.kt
+++ b/localehelper/src/main/java/com/zeugmasolutions/localehelper/LocaleHelperActivities.kt
@@ -12,11 +12,7 @@ open class LocaleAwareCompatActivity : AppCompatActivity() {
 
     override fun getDelegate() = localeDelegate.getAppCompatDelegate(super.getDelegate())
 
-    override fun attachBaseContext(newBase: Context) {
-        super.attachBaseContext(localeDelegate.attachBaseContext(newBase))
-    }
-
-    override fun onCreate(savedInstanceState: Bundle?) {
+        override fun onCreate(savedInstanceState: Bundle?) {
         localeDelegate.onCreate(this)
         super.onCreate(savedInstanceState)
     }

--- a/localehelper/src/main/java/com/zeugmasolutions/localehelper/LocaleHelperDelegates.kt
+++ b/localehelper/src/main/java/com/zeugmasolutions/localehelper/LocaleHelperDelegates.kt
@@ -10,7 +10,6 @@ import java.util.Locale
 
 interface LocaleHelperActivityDelegate {
     fun setLocale(activity: Activity, newLocale: Locale)
-    fun attachBaseContext(newBase: Context): Context
     fun onPaused()
     fun onResumed(activity: Activity)
     fun onCreate(activity: Activity)
@@ -40,8 +39,6 @@ class LocaleHelperActivityDelegateImpl : LocaleHelperActivityDelegate {
         locale = newLocale
         activity.recreate()
     }
-
-    override fun attachBaseContext(newBase: Context): Context = LocaleHelper.onAttach(newBase)
 
     override fun getApplicationContext(applicationContext: Context): Context = applicationContext
 


### PR DESCRIPTION
Closed zeugma-solutions#32

There was incorrect handling of Day/Night theme in the app. Root cause was calling `superDelegate.attachBaseContext2()` in method `androidx.appcompat.app.LocaleHelperAppCompatDelegate#attachBaseContext2`